### PR TITLE
Add include dir to cmake package and export directories to catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ find_package(catkin REQUIRED cmake_modules COMPONENTS
         std_srvs
         message_generation
         )
-
+INCLUDE_DIRECTORIES(    include 
+                        ${catkin_INCLUDE_DIRS})
 add_message_files(
         DIRECTORY
         msgs
@@ -36,4 +37,5 @@ generate_messages(
         DEPENDENCIES std_msgs
 )
 
-catkin_package(CATKIN_DEPENDS message_runtime message_generation)
+catkin_package( CATKIN_DEPENDS roscpp message_runtime message_generation
+                INCLUDE_DIRS include)


### PR DESCRIPTION
Being a CATKIN package we can make use of the find_package command to find packages and their exported targets and include directories.

We do this by 
`INCLUDE_DIRECTORIES(    include 
                        ${catkin_INCLUDE_DIRS})`
Which tells catkin to include the local folder 'include' as well as all include folders exported by all the find_package(catkin ...)'ed catkin_packages
